### PR TITLE
Fixes for blender 2.8 lib upgrade in August 2018

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,17 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
     yasm \
     wget \
     gawk \
-    && rm -rf /var/lib/apt/lists/*
+	nasm \
+	tcl \
+    python \
+	libffi-dev \
+    libopenjp2-7-dev \
+    && rm -rf /var/lib/apt/lists/* \
+	&& wget https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.gz \
+	&& tar xzf nasm-2.13.03.tar.gz \
+	&& cd nasm-2.13.03 \
+	&& ./configure && make && make install
+	
 
 VOLUME /data/blender /data/lib /data/build
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ function config_blender() {
 # openal seems to be the only one that cmake can't set correctly, doing manually that.
 
   cmake ${BLENDER_SRC_DIR} -C${BLENDER_SRC_DIR}/build_files/cmake/config/blender_release.cmake -DWITH_PLAYER=OFF \
-    -DOPENAL_LIBRARY=${LIB_DIR}/openal/lib/libopenal.a -DOPENAL_INCLUDE_DIR=${LIB_DIR}/openal/include
+    -DOPENAL_LIBRARY=${LIB_DIR}/openal/lib/libopenal.a -DOPENAL_INCLUDE_DIR=${LIB_DIR}/openal/include/AL -DWITH_SYSTEM_OPENJPEG=ON
 }
 
 function build_blender() {


### PR DESCRIPTION
some fixes to be able to build the libraries and blender inside the docker container.
On the host machine, linux mint 19, building the libraries did not work (for me).
Since docker is very similar to a chroot, but easier to handle, I decided to attempt to fix this
dockerfile and entryscript.
Probably it would be better to not build nasm 2.0.13 from source, but instead get it from
stretch-backports via new repo and pinning, but building from source turned out as the 
quicker solution.